### PR TITLE
Add “say” endpoint for notifications and comedic effect

### DIFF
--- a/scripts/httpd.coffee
+++ b/scripts/httpd.coffee
@@ -12,6 +12,7 @@
 #
 # URLS:
 #   /hubot/version
+#   /hubot/say/:room
 #   /hubot/ping
 #   /hubot/time
 #   /hubot/info
@@ -26,6 +27,16 @@ module.exports = (robot) ->
 
   robot.router.post "/hubot/ping", (req, res) ->
     res.end "PONG"
+
+  robot.router.post "/hubot/say/:room?", (req, res) ->
+    if req.body.text && req.body.token && req.body.token == process.env.HUBOT_SAY_TOKEN
+      room = req.params.room || "dev"
+      text = req.body.text
+
+      robot.send "#" + room, text
+      res.end ";)"
+    else
+      res.end ":("
 
   robot.router.get "/hubot/time", (req, res) ->
     res.end "Server time is: #{new Date()}"

--- a/scripts/httpd.coffee
+++ b/scripts/httpd.coffee
@@ -28,15 +28,16 @@ module.exports = (robot) ->
   robot.router.post "/hubot/ping", (req, res) ->
     res.end "PONG"
 
-  robot.router.post "/hubot/say/:room?", (req, res) ->
-    if req.body.text && req.body.token && req.body.token == process.env.HUBOT_SAY_TOKEN
-      room = req.params.room || "dev"
-      text = req.body.text
+  if process.env.HUBOT_SAY_TOKEN
+    robot.router.post "/hubot/say/:room?", (req, res) ->
+      if req.body.text && req.body.token && req.body.token == process.env.HUBOT_SAY_TOKEN
+        room = req.params.room || "dev"
+        text = req.body.text
 
-      robot.send "#" + room, text
-      res.end ";)"
-    else
-      res.end ":("
+        robot.send "#" + room, text
+        res.end ";)"
+      else
+        res.end ":("
 
   robot.router.get "/hubot/time", (req, res) ->
     res.end "Server time is: #{new Date()}"


### PR DESCRIPTION
Adds "/hubot/say/:room" endpoint to post stuff to chat. Requires a JSON payload with `text` and `token` params which is compared to `ENV["HUBOT_SAY_TOKEN"]`.
